### PR TITLE
feat: add Orchard CRUD utilities

### DIFF
--- a/docs/ORCHARD_SETUP.md
+++ b/docs/ORCHARD_SETUP.md
@@ -46,3 +46,14 @@ Once Orchard Core is running:
 3. Manage SEO options in **Configuration → Settings → SEO**.
 4. The front‑end in this repository can fetch rendered pages or use Orchard's APIs for dynamic content.
 
+## Front-end Integration
+
+Utilities for interacting with Orchard's Content API live in `src/lib/orchard.ts` with React Query hooks in `src/hooks/useOrchardPage.ts`.
+Set the `VITE_ORCHARD_API_URL` environment variable to the base URL of your Orchard instance (e.g. `http://localhost:8080`).
+
+```ts
+import { useOrchardPage } from "@/hooks/useOrchardPage"
+
+const { data } = useOrchardPage("home")
+```
+

--- a/src/hooks/useOrchardPage.ts
+++ b/src/hooks/useOrchardPage.ts
@@ -1,0 +1,50 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  createPage,
+  deletePage,
+  getPage,
+  listPages,
+  updatePage,
+  type OrchardPage,
+} from "@/lib/orchard"
+
+export const useOrchardPages = () =>
+  useQuery({ queryKey: ["orchard", "pages"], queryFn: listPages })
+
+export const useOrchardPage = (id: string) =>
+  useQuery({
+    queryKey: ["orchard", "page", id],
+    queryFn: () => getPage(id),
+    enabled: !!id,
+  })
+
+export const useCreateOrchardPage = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: createPage,
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["orchard", "pages"] }),
+  })
+}
+
+export const useUpdateOrchardPage = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, page }: { id: string; page: Partial<OrchardPage> }) =>
+      updatePage(id, page),
+    onSuccess: (_, { id }) => {
+      qc.invalidateQueries({ queryKey: ["orchard", "page", id] })
+      qc.invalidateQueries({ queryKey: ["orchard", "pages"] })
+    },
+  })
+}
+
+export const useDeleteOrchardPage = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: deletePage,
+    onSuccess: (_, id) => {
+      qc.invalidateQueries({ queryKey: ["orchard", "page", id] })
+      qc.invalidateQueries({ queryKey: ["orchard", "pages"] })
+    },
+  })
+}

--- a/src/lib/orchard.ts
+++ b/src/lib/orchard.ts
@@ -1,0 +1,47 @@
+export interface OrchardPage {
+  contentItemId?: string
+  displayText: string
+  contentType?: string
+  [key: string]: unknown
+}
+
+const API_BASE = import.meta.env.VITE_ORCHARD_API_URL ?? "http://localhost:8080"
+
+async function request(path: string, init: RequestInit = {}) {
+  const res = await fetch(`${API_BASE}${path}`, {
+    headers: { "Content-Type": "application/json", ...(init.headers || {}) },
+    ...init,
+  })
+
+  if (!res.ok) {
+    throw new Error(`Orchard request failed: ${res.status}`)
+  }
+
+  return res.status === 204 ? null : res.json()
+}
+
+export function listPages() {
+  return request("/api/content?contentType=Page")
+}
+
+export function getPage(id: string) {
+  return request(`/api/content/${id}`)
+}
+
+export function createPage(page: OrchardPage) {
+  return request("/api/content", {
+    method: "POST",
+    body: JSON.stringify({ contentType: "Page", ...page }),
+  })
+}
+
+export function updatePage(id: string, page: Partial<OrchardPage>) {
+  return request(`/api/content/${id}`, {
+    method: "PUT",
+    body: JSON.stringify(page),
+  })
+}
+
+export function deletePage(id: string) {
+  return request(`/api/content/${id}`, { method: "DELETE" })
+}

--- a/src/pages/main/Index.tsx
+++ b/src/pages/main/Index.tsx
@@ -6,11 +6,22 @@ import { Testimonials } from "@/components/Testimonials";
 import { WhyChooseUs } from "@/components/WhyChooseUs";
 import { Newsletter } from "@/components/Newsletter";
 import Footer from "@/components/Footer";
+import { useOrchardPage } from "@/hooks/useOrchardPage";
 
 const Index = () => {
+  const { data } = useOrchardPage("home")
+
   return (
     <div className="min-h-screen">
       <HomeHeader />
+      {data?.HtmlBodyPart?.html && (
+        <div
+          className="prose mx-auto p-4"
+          dangerouslySetInnerHTML={{
+            __html: data.HtmlBodyPart.html as string,
+          }}
+        />
+      )}
       <HomeHero />
       <Features />
       <PricingPlans />
@@ -19,7 +30,7 @@ const Index = () => {
       <Newsletter />
       <Footer />
     </div>
-  );
+  )
 };
 
 export default Index;


### PR DESCRIPTION
## Summary
- add Orchard content API client for page CRUD
- expose React Query hooks for creating, updating and deleting pages
- render Orchard CMS content on the home page and document setup

## Testing
- `npm run lint` *(fails: Unexpected any, no-empty-object-type, no-require-imports)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a8c465ac88329b93cb4ac813f6388