### PR TITLE
feat: fetch translations from Orchard CMS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "embla-carousel-react": "^8.6.0",
         "i18next": "^25.3.2",
         "i18next-browser-languagedetector": "^8.2.0",
+        "i18next-http-backend": "^3.0.2",
         "input-otp": "^1.4.2",
         "lucide-react": "^0.462.0",
         "next-themes": "^0.3.0",
@@ -3379,6 +3380,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-fetch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4242,6 +4252,15 @@
         "@babel/runtime": "^7.23.2"
       }
     },
+    "node_modules/i18next-http-backend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-3.0.2.tgz",
+      "integrity": "sha512-PdlvPnvIp4E1sYi46Ik4tBYh/v/NbYfFFgTjkwFl0is8A18s7/bx9aXqsrOax9WUbeNS6mD2oix7Z0yGGf6m5g==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-fetch": "4.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4664,6 +4683,26 @@
       "peerDependencies": {
         "react": "^16.8 || ^17 || ^18",
         "react-dom": "^16.8 || ^17 || ^18"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-releases": {
@@ -5783,6 +5822,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -6067,6 +6112,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "embla-carousel-react": "^8.6.0",
     "i18next": "^25.3.2",
     "i18next-browser-languagedetector": "^8.2.0",
+    "i18next-http-backend": "^3.0.2",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.462.0",
     "next-themes": "^0.3.0",

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -85,7 +85,15 @@ const Header = () => {
     }, 200);
   };
 
-  const navigationItems = [
+  interface NavItem {
+    key: string;
+    label: string;
+    href?: string;
+    external?: boolean;
+    items?: NavItem[];
+  }
+
+  const navigationItems: NavItem[] = [
     {
       key: 'products',
       label: t('navigation.products.title'),
@@ -194,7 +202,7 @@ const Header = () => {
     }
   ];
 
-  const renderMenuItem = (item: any, level: number = 0) => {
+  const renderMenuItem = (item: NavItem, level = 0) => {
     const hasSubItems = item.items && item.items.length > 0;
     const isOpen = openSubMenu === item.key;
     const isExternal = item.external;
@@ -228,7 +236,7 @@ const Header = () => {
             onMouseEnter={() => handleSubMenuEnter(item.key)}
             onMouseLeave={handleSubMenuLeave}
           >
-            {item.items.map((subItem: any) => renderMenuItem(subItem, level + 1))}
+            {item.items?.map((subItem) => renderMenuItem(subItem, level + 1))}
           </ul>
         )}
       </li>
@@ -279,7 +287,7 @@ const Header = () => {
                        onMouseLeave={handleDropdownMenuLeave}
                      >
                        <ul className="py-2">
-                         {item.items.map((subItem: any) => renderMenuItem(subItem))}
+                         {item.items?.map((subItem) => renderMenuItem(subItem))}
                        </ul>
                      </div>
                    )}

--- a/src/components/HomeHeader.tsx
+++ b/src/components/HomeHeader.tsx
@@ -92,7 +92,15 @@ const HomeHeader = () => {
     }, 200);
   };
 
-  const navigationItems = [
+  interface NavItem {
+    key: string;
+    label: string;
+    href?: string;
+    external?: boolean;
+    items?: NavItem[];
+  }
+
+  const navigationItems: NavItem[] = [
     {
       key: 'products',
       label: t('navigation.products.title'),
@@ -211,7 +219,7 @@ const HomeHeader = () => {
     }
   ];
 
-  const renderMenuItem = (item: any, level: number = 0) => {
+  const renderMenuItem = (item: NavItem, level = 0) => {
     const hasSubItems = item.items && item.items.length > 0;
     const isOpen = openSubMenu === item.key;
     const isExternal = item.external;
@@ -245,7 +253,7 @@ const HomeHeader = () => {
             onMouseEnter={() => handleSubMenuEnter(item.key)}
             onMouseLeave={handleSubMenuLeave}
           >
-            {item.items.map((subItem: any) => renderMenuItem(subItem, level + 1))}
+            {item.items?.map((subItem) => renderMenuItem(subItem, level + 1))}
           </ul>
         )}
       </li>
@@ -328,7 +336,7 @@ const HomeHeader = () => {
                         onMouseLeave={handleDropdownMenuLeave}
                       >
                         <ul className="py-2">
-                          {item.items.map((subItem: any) => renderMenuItem(subItem))}
+                          {item.items?.map((subItem) => renderMenuItem(subItem))}
                         </ul>
                       </div>
                     )}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {
@@ -21,4 +20,4 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
 )
 Textarea.displayName = "Textarea"
 
-export { Textarea } 
+export { Textarea }

--- a/src/hooks/useOrchardPage.ts
+++ b/src/hooks/useOrchardPage.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useTranslation } from "react-i18next"
 import {
   createPage,
   deletePage,
@@ -11,12 +12,15 @@ import {
 export const useOrchardPages = () =>
   useQuery({ queryKey: ["orchard", "pages"], queryFn: listPages })
 
-export const useOrchardPage = (id: string) =>
-  useQuery({
-    queryKey: ["orchard", "page", id],
-    queryFn: () => getPage(id),
+export const useOrchardPage = (id: string) => {
+  const { i18n } = useTranslation()
+
+  return useQuery({
+    queryKey: ["orchard", "page", id, i18n.language],
+    queryFn: () => getPage(id, i18n.language),
     enabled: !!id,
   })
+}
 
 export const useCreateOrchardPage = () => {
   const qc = useQueryClient()

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,44 +1,30 @@
-import i18n from 'i18next';
-import { initReactI18next } from 'react-i18next';
-import LanguageDetector from 'i18next-browser-languagedetector';
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import LanguageDetector from "i18next-browser-languagedetector";
+import HttpBackend from "i18next-http-backend";
 
-// Import translations
-import ar from './locales/ar.json';
-import en from './locales/en.json';
-import cn from './locales/cn.json';
-import ru from './locales/ru.json';
-
-const resources = {
-  ar: {
-    translation: ar
-  },
-  en: {
-    translation: en
-  },
-  cn: {
-    translation: cn
-  },
-  ru: {
-    translation: ru
-  }
-};
+const API_BASE = import.meta.env.VITE_ORCHARD_API_URL ?? "http://localhost:8080";
 
 i18n
+  .use(HttpBackend)
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
-    resources,
-    fallbackLng: 'ar',
+    fallbackLng: "ar",
     debug: false,
 
+    backend: {
+      loadPath: `${API_BASE}/api/i18n/{{lng}}`,
+    },
+
     interpolation: {
-      escapeValue: false, // not needed for react as it escapes by default
+      escapeValue: false,
     },
 
     detection: {
-      order: ['localStorage', 'navigator', 'htmlTag'],
-      caches: ['localStorage'],
+      order: ["localStorage", "navigator", "htmlTag"],
+      caches: ["localStorage"],
     },
   });
 
-export default i18n; 
+export default i18n;

--- a/src/lib/orchard.ts
+++ b/src/lib/orchard.ts
@@ -24,8 +24,9 @@ export function listPages() {
   return request("/api/content?contentType=Page")
 }
 
-export function getPage(id: string) {
-  return request(`/api/content/${id}`)
+export function getPage(id: string, culture?: string) {
+  const query = culture ? `?culture=${culture}` : ""
+  return request(`/api/content/${id}${query}`)
 }
 
 export function createPage(page: OrchardPage) {

--- a/src/pages/tools/LookingGlass.tsx
+++ b/src/pages/tools/LookingGlass.tsx
@@ -14,7 +14,9 @@ const LookingGlass = () => {
   const { t } = useTranslation();
   const [selectedLocation, setSelectedLocation] = useState("la");
   const [targetHost, setTargetHost] = useState("");
-  const [testResults, setTestResults] = useState<any>(null);
+  const [testResults, setTestResults] = useState<Record<string, unknown> | null>(
+    null
+  );
   const [isLoading, setIsLoading] = useState(false);
 
   const locations = [

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -101,5 +102,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animatePlugin],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- load i18n translations from Orchard CMS via HTTP backend
- request Orchard pages with culture-specific content and auto fetch current language
- tighten types and fix lint warnings

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a8e9198fc8329ba2932e172d233ac